### PR TITLE
Integrate React framework and refactor Vanta.js animation.

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
 import partytown from '@astrojs/partytown';
 import icon from 'astro-icon';
 import compress from 'astro-compress';
@@ -25,6 +26,7 @@ export default defineConfig({
   output: 'static',
 
   integrations: [
+    react(),
     tailwind({
       applyBaseStyles: false,
     }),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "lodash.merge": "^4.6.2",
     "three": "^0.177.0",
     "unpic": "^4.1.2",
-    "vanta": "^0.5.24"
+    "vanta": "^0.5.24",
+    "@astrojs/react": "^3.6.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
- Add @astrojs/react, react, and react-dom dependencies to package.json.
- Configure React integration in astro.config.ts.
- Create VantaLoader.jsx React component to handle Vanta.js initialization.
- Update index.astro to use VantaLoader with client:only="react" directive.
- Remove previous manual Vanta.js script from index.astro.

This change allows Astro to render React components and aims to resolve issues with Vanta.js initialization by encapsulating it within a client-side React component. User has been instructed to run npm install to get the new dependencies.